### PR TITLE
Feat: multimode keymaps & behavior retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ The above is equivalent to the following VimL:
 nnoremap <silent> gr <Cmd>lua vim.lsp.buf.references()<CR>
 ```
 
+You can set buffer local keymaps:
+```lua
+-- Only buffer sets map to current buffer
+map.n.nore.buffer.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
+-- You can specify bufnr like <bufer=n>
+-- This keymap will be set for buffer no 3
+map.n.nore.buffer3.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
+```
+
 If you're going to have multiple mappings with similar options it's easy to do
 ```lua
 local nnoremap = require 'cartographer'.n.nore.silent

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ The above is equivalent to the following VimL:
 nnoremap <silent> gr <Cmd>lua vim.lsp.buf.references()<CR>
 ```
 
+If you're going to have multiple mappings with similar options it's easy to do
+```lua
+local nnoremap = require 'cartographer'.n.nore.silent
+noremap['key1'] = expr1
+noremap['key2'] = expr2
+-- You can add options on top of this too
+noremap.buffer['key3'] = expr3
+```
+
 You can `:unmap` as well by setting a `<lhs>` to `nil` instead of any `<rhs>`:
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ map.n.nore.buffer3.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
 If you're going to have multiple mappings with similar options it's easy to do
 ```lua
 local nnoremap = require 'cartographer'.n.nore.silent
-noremap['key1'] = expr1
-noremap['key2'] = expr2
+nnoremap['key1'] = expr1
+nnoremap['key2'] = expr2
 -- You can add options on top of this too
-noremap.buffer['key3'] = expr3
+nnoremap.buffer['key3'] = expr3
 ```
 
 You can `:unmap` as well by setting a `<lhs>` to `nil` instead of any `<rhs>`:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,5 @@ You can `:map` to multiple `modes` if necessary. All you must do is use a `for` 
 
 ```lua
 -- Map `gr` to LSP symbol references in 'x' and 'n' modes.
-for _, mode in ipairs({'n', 'x'}) do
-	map[mode].nore.expr['<Tab>'] = 'pumvisible() ? "\\<C-n>" : check_backspace() ? "\\<Tab>" : compe#complete()'
-end
+map.n.x.nore.expr['<Tab>'] = 'pumvisible() ? "\\<C-n>" : check_backspace() ? "\\<Tab>" : compe#complete()'
 ```

--- a/doc/cartographer.txt
+++ b/doc/cartographer.txt
@@ -48,6 +48,15 @@ The above is equivalent to the following VimL: >
 	nnoremap <silent> gr <Cmd>lua vim.lsp.buf.references()<CR>
 <
 
+If you're going to have multiple mappings with similar options it's easy to do
+>
+  local nnoremap = require 'cartographer'.n.nore.silent
+  noremap['key1'] = expr1
+  noremap['key2'] = expr2
+  -- You can add options on top of this too
+  noremap.buffer['key3'] = expr3
+<
+
 You can |:unmap| as well by setting a {lhs} to `nil` instead of any {rhs}: >
 	-- `:unmap` 'zfo' in `x` mode
 	map.x['zfo'] = nil

--- a/doc/cartographer.txt
+++ b/doc/cartographer.txt
@@ -91,9 +91,7 @@ MULTIPLE MODES                                       *cartographer-multiple-mode
 You can |:map| to multiple {mode}s if necessary. All you must do is use a `for`
 loop: >
 	-- Map `gr` to LSP symbol references in 'x' and 'n' modes.
-	for _, mode in ipairs({'n', 'x'}) do
-		map[mode].nore.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
-	end
+	map.n.x.nore.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
 <
 
 ================================================================================

--- a/doc/cartographer.txt
+++ b/doc/cartographer.txt
@@ -47,6 +47,15 @@ The above is equivalent to the following VimL: >
 	" This is how you bind `gr` to the builtin LSP symbol-references command
 	nnoremap <silent> gr <Cmd>lua vim.lsp.buf.references()<CR>
 <
+You can set buffer local keymaps:
+>
+  -- Only buffer sets map to current buffer
+  map.n.nore.buffer.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
+  -- You can specify bufnr like <bufer=n>
+  -- This keymap will be set for buffer no 3
+  map.n.nore.buffer3.silent['gr'] = '<Cmd>lua vim.lsp.buf.references()<CR>'
+<
+
 
 If you're going to have multiple mappings with similar options it's easy to do
 >

--- a/doc/cartographer.txt
+++ b/doc/cartographer.txt
@@ -60,10 +60,10 @@ You can set buffer local keymaps:
 If you're going to have multiple mappings with similar options it's easy to do
 >
   local nnoremap = require 'cartographer'.n.nore.silent
-  noremap['key1'] = expr1
-  noremap['key2'] = expr2
+  nnoremap['key1'] = expr1
+  nnoremap['key2'] = expr2
   -- You can add options on top of this too
-  noremap.buffer['key3'] = expr3
+  nnoremap.buffer['key3'] = expr3
 <
 
 You can |:unmap| as well by setting a {lhs} to `nil` instead of any {rhs}: >

--- a/lua/cartographer.lua
+++ b/lua/cartographer.lua
@@ -34,9 +34,11 @@ MetaCartographer =
 		self = copy(self)
 
 		if #key < 2 then -- set the mode
-			table.insert(rawget(self, '_modes'), key)
+			self._modes[#self._modes+1] = key
+		elseif #key > 5 and key:sub(1, 1) == 'b' then -- PERF: 'buffer' is the only 6-letter option starting with 'b'
+			self.buffer = #key > 6 and tonumber(key:sub(7)) or 0 -- NOTE: 0 is the current buffer
 		else -- the builder
-			rawset(self, key, true)
+			self[key] = true
 		end
 
 		return setmetatable(self, MetaCartographer)
@@ -48,7 +50,8 @@ MetaCartographer =
 	--- @param rhs string if `nil`, |:unmap| lhs. Otherwise, see |:map|.
 	__newindex = function(self, lhs, rhs)
 		local buffer = rawget(self, 'buffer')
-		local modes = rawget(self, '_modes') or {''}
+		local modes = rawget(self, '_modes')
+		modes = #modes > 0 and modes or {''}
 
 		if rhs then
 			local opts =
@@ -69,7 +72,7 @@ MetaCartographer =
 
 			if buffer then
 				for _, mode in ipairs(modes) do
-					api.nvim_buf_set_keymap(0, mode, lhs, rhs, opts)
+					api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, opts)
 				end
 			else
 				for _, mode in ipairs(modes) do
@@ -79,7 +82,7 @@ MetaCartographer =
 		else
 			if buffer then
 				for _, mode in ipairs(modes) do
-					api.nvim_buf_del_keymap(0, mode, lhs)
+					api.nvim_buf_del_keymap(buffer, mode, lhs)
 				end
 			else
 				for _, mode in ipairs(modes) do

--- a/lua/cartographer.lua
+++ b/lua/cartographer.lua
@@ -53,16 +53,20 @@ MetaCartographer =
 				keymap_opts.noremap = true
 			end
 
-			if buffer then
-				return api.nvim_buf_set_keymap(0, mode, lhs, rhs, keymap_opts)
+			for mode, _ in pairs(modes) do
+				if buffer then
+					api.nvim_buf_set_keymap(0, mode, lhs, rhs, keymap_opts)
 			else
-				return api.nvim_set_keymap(mode, lhs, rhs, keymap_opts)
+					api.nvim_set_keymap(mode, lhs, rhs, keymap_opts)
+				end
 			end
 		else
-			if buffer then
-				return api.nvim_buf_del_keymap(0, mode, lhs)
-			else
-				return api.nvim_del_keymap(mode, lhs)
+			for mode, _ in pairs(modes) do
+				if buffer then
+					api.nvim_buf_del_keymap(0, mode, lhs)
+				else
+				api.nvim_del_keymap(mode, lhs)
+				end
 			end
 		end
 	end,

--- a/lua/cartographer.lua
+++ b/lua/cartographer.lua
@@ -21,7 +21,12 @@ MetaCartographer =
 		else -- the builder
 			if not opts[key] then -- the builder
 				opts = vim.deepcopy(opts)
-				opts[key] = true
+				if not vim.startswith(key, 'buffer') then
+					opts[key] = true
+				else
+					local bufnr = tonumber(key:sub(7))
+					opts.buffer = bufnr or 0
+				end
 				return setmetatable({opts = opts}, MetaCartographer)
 			end
 		end
@@ -55,7 +60,7 @@ MetaCartographer =
 
 			for mode, _ in pairs(modes) do
 				if buffer then
-					api.nvim_buf_set_keymap(0, mode, lhs, rhs, keymap_opts)
+					api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, keymap_opts)
 			else
 					api.nvim_set_keymap(mode, lhs, rhs, keymap_opts)
 				end
@@ -63,7 +68,7 @@ MetaCartographer =
 		else
 			for mode, _ in pairs(modes) do
 				if buffer then
-					api.nvim_buf_del_keymap(0, mode, lhs)
+					api.nvim_buf_del_keymap(buffer, mode, lhs)
 				else
 				api.nvim_del_keymap(mode, lhs)
 				end


### PR DESCRIPTION
implementation of ideas from #2 

# Changes
- Now the map tables are isolated so no need to require cartographer all the time . And it allows mapping without long parameters for all maps
- Multiple modes can be maped in one call
- keymaps can be done to specific buffer like `<buffer=3>`. I  this case you'll do `map.buffer3`

closes #2