### PR TITLE
enhance: Escape term codes for expr maps

### DIFF
--- a/lua/cartographer.lua
+++ b/lua/cartographer.lua
@@ -64,6 +64,20 @@ MetaCartographer =
 				unique = rawget(self, 'unique'),
 			}
 
+			-- Handle term codes
+			if opts.expr then
+				local original_rhs = rhs
+				if type(rhs) == 'string' then
+					rhs = function()
+						return vim.api.nvim_replace_termcodes(vim.fn.eval(original_rhs), true, false, true)
+					end
+				elseif type(rhs) == 'function' then
+					rhs = function()
+						return vim.api.nvim_replace_termcodes(original_rhs(), true, false, true)
+					end
+				end
+			end
+
 			if type(rhs) == 'function' then
 				local id = Callbacks.new(rhs)
 				rhs = opts.expr and


### PR DESCRIPTION
This allows you to mappings like:

```lua
local imape = require'cartographer'.i.expr
imape['<tab>'] = "pumvisible()?'<C-n>':'<tab>'"
imape['jk'] = function() return '<esc>' end
```

Without this users need to escape the tercodes themselves before rerurning . I don't even know if that's possible on viml styled string expressions . 