### PR TITLE
fix: copy the buffer field

### DIFF
--- a/lua/cartographer.lua
+++ b/lua/cartographer.lua
@@ -8,6 +8,7 @@ local function new() return {_modes = {}, _opts = {}} end
 local function copy(tbl)
 	local new_tbl = new()
 
+	new_tbl.buffer = rawget(tbl, 'buffer')
 	new_tbl._hook = rawget(tbl, '_hook')
 	for i, val in ipairs(rawget(tbl, '_modes')) do
 		new_tbl._modes[i] = val


### PR DESCRIPTION
Copy the buffer field as well when making a copy of the table.

I ran into this problem when trying to make a buffer-local + nowait mapping,
doing `map.buffer.nowait['d'] = '<c-d>'` ended up applying it globally rather than to the buffer